### PR TITLE
Rework of the SignatureCalculator

### DIFF
--- a/common-test/src/main/scala/gigahorsetest/TestPlan.scala
+++ b/common-test/src/main/scala/gigahorsetest/TestPlan.scala
@@ -41,6 +41,19 @@ class TestPlan extends Plan {
         case Some(Seq(x)) => Ok ~> ResponseString(x)
         case _            => BadRequest ~> ResponseString("args1 is not found!")
       }
+    // sign
+    case r @ GET(Path("/sign")) =>
+      val h = r.headers("X-Signature")
+      if (h.hasNext)
+        Ok ~> ResponseString(s"${h.next()}:${r.parameterValues("query").mkString}")
+      else
+        BadRequest ~> ResponseString("X-Signature header is not found!")
+    case r @ POST(Path("/sign")) =>
+      val h = r.headers("X-Signature")
+      if (h.hasNext)
+        Ok ~> ResponseString(s"${h.next()}:${r.parameterValues("query").mkString}:${r.parameterValues("content").mkString}")
+      else
+        BadRequest ~> ResponseString("X-Signature header is not found!")
     case GET(Path(p)) =>
       println(p)
       Ok ~> ResponseString("foo")

--- a/core/src/main/scala/gigahorse/SignatureCalculator.scala
+++ b/core/src/main/scala/gigahorse/SignatureCalculator.scala
@@ -17,4 +17,6 @@
 
 package gigahorse
 
-abstract class SignatureCalculator
+trait SignatureCalculator {
+  def sign(url: String, contentType: Option[String], content: Array[Byte]): (String, String)
+}


### PR DESCRIPTION
Change the AHC-specific SignatureCalculator to be a generic/common way to add a signature http header derived from url and content.