### PR TITLE
add original + shaded configuration properties

### DIFF
--- a/project/Shade.scala
+++ b/project/Shade.scala
@@ -54,6 +54,8 @@ object Shade {
         // In AsyncHttpClientConfigDefaults.java, the shading renames the resource keys
         // so we have to manually tweak the resource file to match.
         val shadedline = line.replaceAllLiterally("org.asynchttpclient", s"$shadePrefix.org.asynchttpclient")
+        IO.append(file, line)
+        IO.append(file, IO.Newline.getBytes(IO.defaultCharset))
         IO.append(file, shadedline)
         IO.append(file, IO.Newline.getBytes(IO.defaultCharset))
       }


### PR DESCRIPTION
The same problem and solution as described in https://github.com/playframework/play-ws/pull/149:

> completely replacing the configuration properties resulted in errors when users
where using the unshaded AHC-Client in their applications together with play-ws.
As a workaround we take the original properties and add our own properties to the
file. This way, the unshaded client still finds its properties while our own version can
be configured independently