### PR TITLE
Update ssl-config-core to 0.3.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.26"
   val ahc = "org.asynchttpclient" % "async-http-client" % "2.0.39"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.2.4"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.7"
   val reactiveStreams = "org.reactivestreams" % "reactive-streams" % "1.0.2"
   val akkaHttpVersion = "10.1.8"
   val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion


### PR DESCRIPTION
I came here because I care about having typesafe config 1.3.x in sbt (https://github.com/sbt/sbt/issues/4011). It seems it used to be blocked by gigahorse -> ssl-config 0.2.x -> typesafe-config 1.2.x. dependency.

ssl-config-core 0.3.7 depends on typesafe config 1.3.3. 

There's a newer version available (0.4.0), but it wasn't published for Scala 2.10.
