### PR TITLE
Upgrade contraband

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.4")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
The community build failed with sbt 1.4.x because of the scala upgrade.