### PR TITLE
I81 mime type

### DIFF
--- a/apache-http/src/main/scala/gigahorse/support/apachehttp/ApacheHttpClient.scala
+++ b/apache-http/src/main/scala/gigahorse/support/apachehttp/ApacheHttpClient.scala
@@ -103,7 +103,7 @@ class ApacheHttpClient(config: Config) extends HttpClient {
       }
     def buildContentType(opt: Option[String], fallback: ContentType): ContentType =
       opt match {
-        case Some(value) => ContentType.create(value)
+        case Some(value) => ContentType.parse(value)
         case _           => fallback
       }
     def ct: ContentType =

--- a/common-test/src/main/scala/gigahorsetest/BaseHttpClientSpec.scala
+++ b/common-test/src/main/scala/gigahorsetest/BaseHttpClientSpec.scala
@@ -23,8 +23,9 @@ import org.scalatest.matchers.should.Matchers
 import scala.util.Success
 import scala.concurrent._
 import java.io.File
+import java.nio.charset.Charset
 
-import gigahorse.{HeaderNames, SignatureCalculator, WebSocketEvent}
+import gigahorse.{HeaderNames, MimeTypes, SignatureCalculator, WebSocketEvent}
 import unfiltered.scalatest.Hosted
 import unfiltered.netty.Server
 
@@ -108,6 +109,15 @@ abstract class BaseHttpClientSpec extends AsyncFlatSpec with Matchers
       val f = http.run(r.post(Map("arg1" -> List("{}"))), Gigahorse.asString)
       f map { s =>
         assert(s === "{}")
+      }
+    }
+
+  "http.run(r.withContentType(MimeTypes.Text, ISO-8859-1), f)" should "parse and post with correct content type" in
+    withHttp { http =>
+      val r = Gigahorse.url(s"${testUrl}charset")
+      val f = http.run(r.withContentType(MimeTypes.TEXT, Charset.forName("ISO-8859-1")).post("hello world", Charset.forName( "ISO-8859-1")), Gigahorse.asString)
+      f map { s =>
+        assert(s === "text/plain;charset=ISO-8859-1")
       }
     }
 

--- a/common-test/src/main/scala/gigahorsetest/TestPlan.scala
+++ b/common-test/src/main/scala/gigahorsetest/TestPlan.scala
@@ -41,6 +41,12 @@ object TestPlan {
         case Some(Seq(x)) => Ok ~> ResponseString(x)
         case _            => BadRequest ~> ResponseString("args1 is not found!")
       }
+    case r @ POST(Path("/charset")) =>
+      val h = r.headers("Content-Type").filter(_.contains("text/plain"))
+      if (h.hasNext)
+        Ok ~> ResponseString(h.next().replaceAll("\\s", ""))
+      else
+        BadRequest ~> ResponseString("Content-Type header 'text/plain' not found")
     // sign
     case r @ GET(Path("/sign")) =>
       val h = r.headers("X-Signature")


### PR DESCRIPTION
Fixes #81 

Use `parse` method to generate a `ContentType` from a string to better capture the optional charset. 

Thanks very much in advance for reviewing this PR!