### PR TITLE
Update okhttp3 to 4.10.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
   val akkaHttp = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
   val akkaStream = "com.typesafe.akka" %% "akka-stream" % "2.5.32"
-  val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.14.2"
+  val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.10.0"
   val apacheHttpAsyncClient = "org.apache.httpcomponents" % "httpasyncclient" % "4.1.5"
   val unfilteredVersion = "0.10.4"
   val ufDirectives = "ws.unfiltered" %% "unfiltered-directives" % unfilteredVersion


### PR DESCRIPTION
https://github.com/eed3si9n/gigahorse/issues/73

I have tried okhttp3 4.10.0. All tests passed. ✅ 
(Is there any reason why Gigahorse has not upgraded okhttp3 to 4.x ?)