### PR TITLE
Revert FileBody to just upload

### DIFF
--- a/apache-http/src/main/scala/gigahorse/support/apachehttp/ApacheHttpClient.scala
+++ b/apache-http/src/main/scala/gigahorse/support/apachehttp/ApacheHttpClient.scala
@@ -41,6 +41,7 @@ import client5.http.impl.async.{
 import client5.http.impl.auth.CredentialsProviderBuilder
 import client5.http.impl.nio.PoolingAsyncClientConnectionManager
 import core5.concurrent.FutureCallback
+
 import core5.http.{
   ContentType,
   EntityDetails,
@@ -51,6 +52,7 @@ import core5.http.{
   HttpResponse as XResponse,
 }
 import core5.http.nio.{ AsyncEntityProducer, AsyncRequestProducer, DataStreamChannel }
+import core5.http.nio.entity.FileEntityProducer
 import core5.http.nio.support.BasicRequestProducer
 import core5.http.protocol.HttpContext
 import core5.reactor.IOReactorConfig
@@ -119,10 +121,7 @@ class ApacheHttpClient(config: Config) extends HttpClient {
         new BasicRequestProducer(r, entity)
       case b: FileBody =>
         val r = builder.build()
-        val multi = MultipartFormBody(
-          FormPart(b.file.getName(), b.file).withContentType(ct.toString())
-        )
-        val entity = MultipartAsyncEntityProducer(multi)
+        val entity = new FileEntityProducer(b.file, ct)
         new BasicRequestProducer(r, entity)
     }
   }

--- a/asynchttpclient/src/main/scala/gigahorse/support/asynchttpclient/AhcHttpClient.scala
+++ b/asynchttpclient/src/main/scala/gigahorse/support/asynchttpclient/AhcHttpClient.scala
@@ -32,6 +32,7 @@ import shaded.ahc.org.asynchttpclient.{
 }
 import shaded.ahc.org.asynchttpclient.AsyncHandler.{ State as XState }
 import shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler
+import shaded.ahc.org.asynchttpclient.request.body.generator.FileBodyGenerator
 import shaded.ahc.org.asynchttpclient.request.body.multipart.{ ByteArrayPart, FilePart }
 import shaded.ahc.org.asynchttpclient.proxy.{ ProxyServer as XProxyServer, ProxyType as XProxyType }
 import shaded.ahc.org.asynchttpclient.Realm.{ AuthScheme as XAuthScheme }
@@ -216,9 +217,9 @@ class AhcHttpClient(config: AsyncHttpClientConfig) extends ReactiveHttpClient {
         builder.setBody(b.bytes)
         (builder, request.headers)
       case b: FileBody =>
-        val ct = contentType.getOrElse("application/octet-stream")
-        builder.addBodyPart(new FilePart(b.file.getName(), b.file, ct, null))
-        (builder, request.headers.updated(HeaderNames.CONTENT_TYPE, List("multipart/form-data")))
+        val bodyGenerator = new FileBodyGenerator(b.file)
+        builder.setBody(bodyGenerator)
+        (builder, request.headers)
       case b: MultipartFormBody =>
         for { p <- b.parts } {
           p.body match {

--- a/common-test/src/main/scala/gigahorsetest/BaseHttpClientSpec.scala
+++ b/common-test/src/main/scala/gigahorsetest/BaseHttpClientSpec.scala
@@ -43,6 +43,7 @@ abstract class BaseHttpClientSpec extends AsyncFlatSpec with Matchers with TestH
     _.handler(WsTestPlan.testPlan)
   }
   def isWebSocketSupported: Boolean = true
+  def uploadEndpoint = "upload"
 
   // custom loan pattern
   def withHttp(testCode: gigahorse.HttpClient => Future[Assertion]): Future[Assertion]
@@ -253,7 +254,7 @@ abstract class BaseHttpClientSpec extends AsyncFlatSpec with Matchers with TestH
   }"""
         FileUtil.write(file, content)
         val r = Gigahorse
-          .url(s"${testUrl}upload")
+          .url(s"${testUrl}${uploadEndpoint}")
           .post(file)
           .withContentType("application/json")
         for {

--- a/common-test/src/main/scala/gigahorsetest/TestPlan.scala
+++ b/common-test/src/main/scala/gigahorsetest/TestPlan.scala
@@ -72,7 +72,10 @@ object TestPlan {
       FileUtil.transfer(r, baos)
       Ok ~> ResponseBytes(baos.toByteArray())
     // upload
-    case POST(Path("/upload") & MultiPart(r)) =>
+    case r @ POST(Path("/upload")) =>
+      val body = FileUtil.read(r.inputStream)
+      Ok ~> ResponseString(body)
+    case POST(Path("/upload-as-multipart") & MultiPart(r)) =>
       val mem = MultiPartParams.Memory(r)
       val f = mem.files("a.json").head
       val body = f.stream(FileUtil.read)

--- a/okhttp/src/main/scala/gigahorse/support/okhttp/OkhClient.scala
+++ b/okhttp/src/main/scala/gigahorse/support/okhttp/OkhClient.scala
@@ -106,13 +106,10 @@ class OkhClient(config: Config) extends HttpClient {
           b.bytes
         )
       case b: FileBody =>
-        var builder = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        val body = RequestBody.create(
+        RequestBody.create(
           MediaType.parse(contentType.getOrElse("application/octet-stream")),
           b.file
         )
-        builder = builder.addFormDataPart(b.file.getName(), b.file.getName(), body)
-        builder.build()
       case b: MultipartFormBody =>
         var builder = new MultipartBody.Builder().setType(MultipartBody.FORM)
         for { p <- b.parts } {

--- a/pekko-http/src/test/scala/gigahorsetest/PekkoHttpClientSpec.scala
+++ b/pekko-http/src/test/scala/gigahorsetest/PekkoHttpClientSpec.scala
@@ -24,6 +24,8 @@ import scala.annotation.nowarn
 import scala.concurrent.Future
 
 class PekkoHttpClientSpec extends BaseHttpClientSpec {
+  override def uploadEndpoint: String = "upload-as-multipart"
+
   // custom loan pattern
   override def withHttp(testCode: gigahorse.HttpClient => Future[Assertion]): Future[Assertion] = {
     import gigahorse.support.pekkohttp.Gigahorse


### PR DESCRIPTION
## Problem
When I added multipart form data support, I unified single file upload also to use multipart form, which I don't think was necessary.

## Solution
This reverts the change for all backends except for Pekko HTTP, whose example code seems to show multipart form.